### PR TITLE
Fix compiler warnings: disambiguate a shadowed ivar (view vs. aView)

### DIFF
--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -124,9 +124,9 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 	MBProgressHUD *hud = nil;
 	NSArray *subviews = view.subviews;
 	Class hudClass = [MBProgressHUD class];
-	for (UIView *view in subviews) {
-		if ([view isKindOfClass:hudClass]) {
-			hud = (MBProgressHUD *)view;
+	for (UIView *aView in subviews) {
+		if ([aView isKindOfClass:hudClass]) {
+			hud = (MBProgressHUD *)aView;
 		}
 	}
 	return hud;
@@ -136,9 +136,9 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 	NSMutableArray *huds = [NSMutableArray array];
 	NSArray *subviews = view.subviews;
 	Class hudClass = [MBProgressHUD class];
-	for (UIView *view in subviews) {
-		if ([view isKindOfClass:hudClass]) {
-			[huds addObject:view];
+	for (UIView *aView in subviews) {
+		if ([aView isKindOfClass:hudClass]) {
+			[huds addObject:aView];
 		}
 	}
 	return [NSArray arrayWithArray:huds];


### PR DESCRIPTION
The `view` function parameter was being shadowed by `view` in the enumeration loop. (I added `MBProgressHUD` to a project with pretty strict compiler settings.)
