### PR TITLE
Choose whether to block touches when the HUD is visible

### DIFF
--- a/MBProgressHUD.h
+++ b/MBProgressHUD.h
@@ -397,6 +397,12 @@ typedef void (^MBProgressHUDCompletionBlock)();
  */
 @property (assign, getter = isSquare) BOOL square;
 
+/**
+ * Blocks touches from reaching the containing view. 
+ * Defaults to YES. 
+ */
+@property (assign) BOOL blockTouches;
+
 @end
 
 

--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -85,6 +85,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 @synthesize minShowTimer;
 @synthesize taskInProgress;
 @synthesize removeFromSuperViewOnHide;
+@synthesize blockTouches;
 @synthesize customView;
 @synthesize showStarted;
 @synthesize mode;
@@ -171,6 +172,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 		self.removeFromSuperViewOnHide = NO;
 		self.minSize = CGSizeZero;
 		self.square = NO;
+        self.blockTouches = YES;
 		self.autoresizingMask = UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin 
 								| UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
 
@@ -709,6 +711,19 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 	if (animated) {
 		[UIView commitAnimations];
 	}
+}
+
+#pragma mark - Touch Handling
+
+- (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event
+{
+    if (self.blockTouches) {
+        // Capture all touches in the superview
+        return [self.superview pointInside:[self convertPoint:point toView:self.superview] withEvent:event];
+    } else {
+        // Don't handle any touches
+        return NO;
+    }
 }
 
 @end


### PR DESCRIPTION
Added a boolean property controlling whether the view blocks touches or passes them through to the superview.
This changes fixes issue #3 and issue #34.
