### PR TITLE
Implemented ´hudViewDidReceiveTouch:´ delegate method getting called

### DIFF
--- a/Demo/Classes/HudDemoViewController.m
+++ b/Demo/Classes/HudDemoViewController.m
@@ -289,4 +289,8 @@
 	HUD = nil;
 }
 
+- (void)hudViewDidReceiveTouch:(MBProgressHUD *)hud {
+	NSLog(@"hudViewDidReceiveTouch:");
+}
+
 @end

--- a/MBProgressHUD.h
+++ b/MBProgressHUD.h
@@ -412,6 +412,11 @@ typedef void (^MBProgressHUDCompletionBlock)();
  */
 - (void)hudWasHidden:(MBProgressHUD *)hud;
 
+/**
+ * Called if user touches the HUD
+ */
+- (void)hudViewDidReceiveTouch:(MBProgressHUD *)hud;
+
 @end
 
 

--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -187,6 +187,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 		[self updateIndicators];
 		[self registerForKVO];
 		[self registerForNotifications];
+        [self initializeGestureRecognizers];
 	}
 	return self;
 }
@@ -717,6 +718,20 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 	[self setTransform:rotationTransform];
 	if (animated) {
 		[UIView commitAnimations];
+	}
+}
+
+#pragma mark - Gesturerecognizers
+- (void) initializeGestureRecognizers {
+    UITapGestureRecognizer *singleFingerTap = [[UITapGestureRecognizer alloc] initWithTarget:self
+                                                                                      action:@selector(handleSingleHudTap:)];
+    singleFingerTap.numberOfTapsRequired = 1;
+    [self addGestureRecognizer:singleFingerTap];
+}
+
+- (void) handleSingleHudTap:(id)sender {
+    if ([delegate respondsToSelector:@selector(hudViewDidReceiveTouch:)]) {
+		[delegate performSelector:@selector(hudViewDidReceiveTouch:) withObject:self];
 	}
 }
 


### PR DESCRIPTION
User may use this action e.g. to cancel requests or perform other tasks if user touches the HUD.
