### PR TITLE
Add AppCode folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ profile
 # vim noise
 *~
 *.swp
+
+# AppCode noise
+.idea/


### PR DESCRIPTION
AppCode is a pretty decent alternative to (parts of) Xcode, by the people behind IntelliJ IDEA. But it leaves this annoying .idea folder in your project folder. This ignores it.
