### PR TITLE
Fix typo in MBProgressHUD

### DIFF
--- a/MBProgressHUD.h
+++ b/MBProgressHUD.h
@@ -332,7 +332,7 @@ typedef void (^MBProgressHUDCompletionBlock)();
 @property (assign) float xOffset;
 
 /** 
- * The y-ayis offset of the HUD relative to the centre of the superview. 
+ * The y-axis offset of the HUD relative to the centre of the superview. 
  */
 @property (assign) float yOffset;
 


### PR DESCRIPTION
Typo (or aggressive find/replace) caused an "x-axis" (correct)
and "y-ayis" (wot?).
