### PR TITLE
Added an accessory view to MBProgressHUD.

### DIFF
--- a/MBProgressHUD.h
+++ b/MBProgressHUD.h
@@ -60,27 +60,27 @@ typedef enum {
 
 #ifndef MB_INSTANCETYPE
 #if __has_feature(objc_instancetype)
-#define MB_INSTANCETYPE instancetype
+	#define MB_INSTANCETYPE instancetype
 #else
-#define MB_INSTANCETYPE id
+	#define MB_INSTANCETYPE id
 #endif
 #endif
 
 #ifndef MB_STRONG
 #if __has_feature(objc_arc)
-#define MB_STRONG strong
+	#define MB_STRONG strong
 #else
-#define MB_STRONG retain
+	#define MB_STRONG retain
 #endif
 #endif
 
 #ifndef MB_WEAK
 #if __has_feature(objc_arc_weak)
-#define MB_WEAK weak
+	#define MB_WEAK weak
 #elif __has_feature(objc_arc)
-#define MB_WEAK unsafe_unretained
+	#define MB_WEAK unsafe_unretained
 #else
-#define MB_WEAK assign
+	#define MB_WEAK assign
 #endif
 #endif
 
@@ -267,7 +267,7 @@ typedef void (^MBProgressHUDCompletionBlock)();
  * @see completionBlock
  */
 - (void)showAnimated:(BOOL)animated whileExecutingBlock:(dispatch_block_t)block onQueue:(dispatch_queue_t)queue
-	 completionBlock:(MBProgressHUDCompletionBlock)completion;
+		  completionBlock:(MBProgressHUDCompletionBlock)completion;
 
 /**
  * A block that gets called after the HUD was completely hidden.
@@ -459,7 +459,7 @@ typedef void (^MBProgressHUDCompletionBlock)();
 
 
 /**
- * A flat bar progress view.
+ * A flat bar progress view. 
  */
 @interface MBBarProgressView : UIView
 

--- a/MBProgressHUD.h
+++ b/MBProgressHUD.h
@@ -4,7 +4,7 @@
 //  Created by Matej Bukovinski on 2.4.09.
 //
 
-// This code is distributed under the terms and conditions of the MIT license. 
+// This code is distributed under the terms and conditions of the MIT license.
 
 // Copyright (c) 2013 Matej Bukovinski
 //
@@ -60,27 +60,27 @@ typedef enum {
 
 #ifndef MB_INSTANCETYPE
 #if __has_feature(objc_instancetype)
-	#define MB_INSTANCETYPE instancetype
+#define MB_INSTANCETYPE instancetype
 #else
-	#define MB_INSTANCETYPE id
+#define MB_INSTANCETYPE id
 #endif
 #endif
 
 #ifndef MB_STRONG
 #if __has_feature(objc_arc)
-	#define MB_STRONG strong
+#define MB_STRONG strong
 #else
-	#define MB_STRONG retain
+#define MB_STRONG retain
 #endif
 #endif
 
 #ifndef MB_WEAK
 #if __has_feature(objc_arc_weak)
-	#define MB_WEAK weak
+#define MB_WEAK weak
 #elif __has_feature(objc_arc)
-	#define MB_WEAK unsafe_unretained
+#define MB_WEAK unsafe_unretained
 #else
-	#define MB_WEAK assign
+#define MB_WEAK assign
 #endif
 #endif
 
@@ -89,7 +89,7 @@ typedef void (^MBProgressHUDCompletionBlock)();
 #endif
 
 
-/** 
+/**
  * Displays a simple HUD window containing a progress indicator and two optional labels for short messages.
  *
  * This is a simple drop-in class for displaying a progress HUD view similar to Apple's private UIProgressHUD class.
@@ -112,7 +112,7 @@ typedef void (^MBProgressHUDCompletionBlock)();
 
 /**
  * Creates a new HUD, adds it to provided view and shows it. The counterpart to this method is hideHUDForView:animated:.
- * 
+ *
  * @param view The view that the HUD will be added to
  * @param animated If set to YES the HUD will appear using the current animationType. If set to NO the HUD will not use
  * animations while appearing.
@@ -129,7 +129,7 @@ typedef void (^MBProgressHUDCompletionBlock)();
  * @param view The view that is going to be searched for a HUD subview.
  * @param animated If set to YES the HUD will disappear using the current animationType. If set to NO the HUD will not use
  * animations while disappearing.
- * @return YES if a HUD was found and removed, NO otherwise. 
+ * @return YES if a HUD was found and removed, NO otherwise.
  *
  * @see showHUDAddedTo:animated:
  * @see animationType
@@ -137,7 +137,7 @@ typedef void (^MBProgressHUDCompletionBlock)();
 + (BOOL)hideHUDForView:(UIView *)view animated:(BOOL)animated;
 
 /**
- * Finds all the HUD subviews and hides them. 
+ * Finds all the HUD subviews and hides them.
  *
  * @param view The view that is going to be searched for HUD subviews.
  * @param animated If set to YES the HUDs will disappear using the current animationType. If set to NO the HUDs will not use
@@ -150,7 +150,7 @@ typedef void (^MBProgressHUDCompletionBlock)();
 + (NSUInteger)hideAllHUDsForView:(UIView *)view animated:(BOOL)animated;
 
 /**
- * Finds the top-most HUD subview and returns it. 
+ * Finds the top-most HUD subview and returns it.
  *
  * @param view The view that is going to be searched.
  * @return A reference to the last HUD subview discovered.
@@ -183,7 +183,7 @@ typedef void (^MBProgressHUDCompletionBlock)();
  */
 - (id)initWithView:(UIView *)view;
 
-/** 
+/**
  * Display the HUD. You need to make sure that the main thread completes its run loop soon after this method call so
  * the user interface can be updated. Call this method when your task is already set-up to be executed in a new thread
  * (e.g., when using something like NSOperation or calling an asynchronous call like NSURLRequest).
@@ -195,7 +195,7 @@ typedef void (^MBProgressHUDCompletionBlock)();
  */
 - (void)show:(BOOL)animated;
 
-/** 
+/**
  * Hide the HUD. This still calls the hudWasHidden: delegate. This is the counterpart of the show: method. Use it to
  * hide the HUD when your task completes.
  *
@@ -206,7 +206,7 @@ typedef void (^MBProgressHUDCompletionBlock)();
  */
 - (void)hide:(BOOL)animated;
 
-/** 
+/**
  * Hide the HUD after a delay. This still calls the hudWasHidden: delegate. This is the counterpart of the show: method. Use it to
  * hide the HUD when your task completes.
  *
@@ -218,7 +218,7 @@ typedef void (^MBProgressHUDCompletionBlock)();
  */
 - (void)hide:(BOOL)animated afterDelay:(NSTimeInterval)delay;
 
-/** 
+/**
  * Shows the HUD while a background task is executing in a new thread, then hides the HUD.
  *
  * This method also takes care of autorelease pools so your method does not have to be concerned with setting up a
@@ -255,7 +255,7 @@ typedef void (^MBProgressHUDCompletionBlock)();
  */
 - (void)showAnimated:(BOOL)animated whileExecutingBlock:(dispatch_block_t)block onQueue:(dispatch_queue_t)queue;
 
-/** 
+/**
  * Shows the HUD while a block is executing on the specified dispatch queue, executes completion block on the main queue, and then hides the HUD.
  *
  * @param animated If set to YES the HUD will (dis)appear using the current animationType. If set to NO the HUD will
@@ -267,7 +267,7 @@ typedef void (^MBProgressHUDCompletionBlock)();
  * @see completionBlock
  */
 - (void)showAnimated:(BOOL)animated whileExecutingBlock:(dispatch_block_t)block onQueue:(dispatch_queue_t)queue
-		  completionBlock:(MBProgressHUDCompletionBlock)completion;
+	 completionBlock:(MBProgressHUDCompletionBlock)completion;
 
 /**
  * A block that gets called after the HUD was completely hidden.
@@ -276,7 +276,7 @@ typedef void (^MBProgressHUDCompletionBlock)();
 
 #endif
 
-/** 
+/**
  * MBProgressHUD operation mode. The default is MBProgressHUDModeIndeterminate.
  *
  * @see MBProgressHUDMode
@@ -284,7 +284,7 @@ typedef void (^MBProgressHUDCompletionBlock)();
 @property (assign) MBProgressHUDMode mode;
 
 /**
- * The animation type that should be used when the HUD is shown and hidden. 
+ * The animation type that should be used when the HUD is shown and hidden.
  *
  * @see MBProgressHUDAnimation
  */
@@ -292,32 +292,32 @@ typedef void (^MBProgressHUDCompletionBlock)();
 
 /**
  * The UIView (e.g., a UIImageView) to be shown when the HUD is in MBProgressHUDModeCustomView.
- * For best results use a 37 by 37 pixel view (so the bounds match the built in indicator bounds). 
+ * For best results use a 37 by 37 pixel view (so the bounds match the built in indicator bounds).
  */
 @property (MB_STRONG) UIView *customView;
 
-/** 
- * The HUD delegate object. 
+/**
+ * The HUD delegate object.
  *
  * @see MBProgressHUDDelegate
  */
 @property (MB_WEAK) id<MBProgressHUDDelegate> delegate;
 
-/** 
+/**
  * An optional short message to be displayed below the activity indicator. The HUD is automatically resized to fit
  * the entire text. If the text is too long it will get clipped by displaying "..." at the end. If left unchanged or
  * set to @"", then no message is displayed.
  */
 @property (copy) NSString *labelText;
 
-/** 
+/**
  * An optional details message displayed below the labelText message. This message is displayed only if the labelText
- * property is also set and is different from an empty string (@""). The details text can span multiple lines. 
+ * property is also set and is different from an empty string (@""). The details text can span multiple lines.
  */
 @property (copy) NSString *detailsLabelText;
 
-/** 
- * The opacity of the HUD window. Defaults to 0.8 (80% opacity). 
+/**
+ * The opacity of the HUD window. Defaults to 0.8 (80% opacity).
  */
 @property (assign) float opacity;
 
@@ -328,37 +328,31 @@ typedef void (^MBProgressHUDCompletionBlock)();
  */
 @property (MB_STRONG) UIColor *color;
 
-/** 
- * The x-axis offset of the HUD relative to the centre of the superview. 
+/**
+ * The x-axis offset of the HUD relative to the centre of the superview.
  */
 @property (assign) float xOffset;
 
-/** 
- * The y-axis offset of the HUD relative to the centre of the superview. 
+/**
+ * The y-axis offset of the HUD relative to the centre of the superview.
  */
 @property (assign) float yOffset;
 
 /**
- * The amount of space between the HUD edge and the HUD elements (labels, indicators or custom views). 
+ * The amount of space between the HUD edge and the HUD elements (labels, indicators or custom views).
  * Defaults to 20.0
  */
 @property (assign) float margin;
 
 /**
- * The corner radius for th HUD
- * Defaults to 10.0
- */
-@property (assign) float cornerRadius;
-
-/** 
- * Cover the HUD background view with a radial gradient. 
+ * Cover the HUD background view with a radial gradient.
  */
 @property (assign) BOOL dimBackground;
 
 /*
- * Grace period is the time (in seconds) that the invoked method may be run without 
+ * Grace period is the time (in seconds) that the invoked method may be run without
  * showing the HUD. If the task finishes before the grace time runs out, the HUD will
- * not be shown at all. 
+ * not be shown at all.
  * This may be used to prevent HUD display for very short tasks.
  * Defaults to 0 (no grace time).
  * Grace time functionality is only supported when the task status is known!
@@ -367,7 +361,7 @@ typedef void (^MBProgressHUDCompletionBlock)();
 @property (assign) float graceTime;
 
 /**
- * The minimum time (in seconds) that the HUD is shown. 
+ * The minimum time (in seconds) that the HUD is shown.
  * This avoids the problem of the HUD being shown and than instantly hidden.
  * Defaults to 0 (no minimum show time).
  */
@@ -378,39 +372,29 @@ typedef void (^MBProgressHUDCompletionBlock)();
  * If you don't set a graceTime (different than 0.0) this does nothing.
  * This property is automatically set when using showWhileExecuting:onTarget:withObject:animated:.
  * When threading is done outside of the HUD (i.e., when the show: and hide: methods are used directly),
- * you need to set this property when your task starts and completes in order to have normal graceTime 
+ * you need to set this property when your task starts and completes in order to have normal graceTime
  * functionality.
  */
 @property (assign) BOOL taskInProgress;
 
 /**
- * Removes the HUD from its parent view when hidden. 
- * Defaults to NO. 
+ * Removes the HUD from its parent view when hidden.
+ * Defaults to NO.
  */
 @property (assign) BOOL removeFromSuperViewOnHide;
 
-/** 
- * Font to be used for the main label. Set this property if the default is not adequate. 
+/**
+ * Font to be used for the main label. Set this property if the default is not adequate.
  */
 @property (MB_STRONG) UIFont* labelFont;
-
-/**
- * Color to be used for the main label. Set this property if the default is not adequate.
- */
-@property (MB_STRONG) UIColor* labelColor;
 
 /**
  * Font to be used for the details label. Set this property if the default is not adequate.
  */
 @property (MB_STRONG) UIFont* detailsLabelFont;
 
-/** 
- * Color to be used for the details label. Set this property if the default is not adequate.
- */
-@property (MB_STRONG) UIColor* detailsLabelColor;
-
-/** 
- * The progress of the progress indicator, from 0.0 to 1.0. Defaults to 0.0. 
+/**
+ * The progress of the progress indicator, from 0.0 to 1.0. Defaults to 0.0.
  */
 @property (assign) float progress;
 
@@ -420,9 +404,14 @@ typedef void (^MBProgressHUDCompletionBlock)();
 @property (assign) CGSize minSize;
 
 /**
- * Force the HUD dimensions to be equal if possible. 
+ * Force the HUD dimensions to be equal if possible.
  */
 @property (assign, getter = isSquare) BOOL square;
+
+/**
+ *  An accessory view displayed directly underneath the bottom most label or indicator.
+ */
+@property (atomic, MB_STRONG) UIView* accessoryView;
 
 @end
 
@@ -431,8 +420,8 @@ typedef void (^MBProgressHUDCompletionBlock)();
 
 @optional
 
-/** 
- * Called after the HUD was fully hidden from the screen. 
+/**
+ * Called after the HUD was fully hidden from the screen.
  */
 - (void)hudWasHidden:(MBProgressHUD *)hud;
 
@@ -442,7 +431,7 @@ typedef void (^MBProgressHUDCompletionBlock)();
 /**
  * A progress view for showing definite progress by filling up a circle (pie chart).
  */
-@interface MBRoundProgressView : UIView 
+@interface MBRoundProgressView : UIView
 
 /**
  * Progress (0.0 to 1.0)
@@ -470,7 +459,7 @@ typedef void (^MBProgressHUDCompletionBlock)();
 
 
 /**
- * A flat bar progress view. 
+ * A flat bar progress view.
  */
 @interface MBBarProgressView : UIView
 

--- a/MBProgressHUD.h
+++ b/MBProgressHUD.h
@@ -328,8 +328,8 @@ typedef void (^MBProgressHUDCompletionBlock)();
  */
 @property (MB_STRONG) UIColor *color;
 
-/**
- * The x-axis offset of the HUD relative to the centre of the superview.
+/** 
+ * The x-axis offset of the HUD relative to the centre of the superview. 
  */
 @property (assign) float xOffset;
 

--- a/MBProgressHUD.h
+++ b/MBProgressHUD.h
@@ -4,7 +4,7 @@
 //  Created by Matej Bukovinski on 2.4.09.
 //
 
-// This code is distributed under the terms and conditions of the MIT license.
+// This code is distributed under the terms and conditions of the MIT license. 
 
 // Copyright (c) 2013 Matej Bukovinski
 //
@@ -89,7 +89,7 @@ typedef void (^MBProgressHUDCompletionBlock)();
 #endif
 
 
-/**
+/** 
  * Displays a simple HUD window containing a progress indicator and two optional labels for short messages.
  *
  * This is a simple drop-in class for displaying a progress HUD view similar to Apple's private UIProgressHUD class.
@@ -112,7 +112,7 @@ typedef void (^MBProgressHUDCompletionBlock)();
 
 /**
  * Creates a new HUD, adds it to provided view and shows it. The counterpart to this method is hideHUDForView:animated:.
- *
+ * 
  * @param view The view that the HUD will be added to
  * @param animated If set to YES the HUD will appear using the current animationType. If set to NO the HUD will not use
  * animations while appearing.
@@ -129,7 +129,7 @@ typedef void (^MBProgressHUDCompletionBlock)();
  * @param view The view that is going to be searched for a HUD subview.
  * @param animated If set to YES the HUD will disappear using the current animationType. If set to NO the HUD will not use
  * animations while disappearing.
- * @return YES if a HUD was found and removed, NO otherwise.
+ * @return YES if a HUD was found and removed, NO otherwise. 
  *
  * @see showHUDAddedTo:animated:
  * @see animationType
@@ -137,7 +137,7 @@ typedef void (^MBProgressHUDCompletionBlock)();
 + (BOOL)hideHUDForView:(UIView *)view animated:(BOOL)animated;
 
 /**
- * Finds all the HUD subviews and hides them.
+ * Finds all the HUD subviews and hides them. 
  *
  * @param view The view that is going to be searched for HUD subviews.
  * @param animated If set to YES the HUDs will disappear using the current animationType. If set to NO the HUDs will not use
@@ -150,7 +150,7 @@ typedef void (^MBProgressHUDCompletionBlock)();
 + (NSUInteger)hideAllHUDsForView:(UIView *)view animated:(BOOL)animated;
 
 /**
- * Finds the top-most HUD subview and returns it.
+ * Finds the top-most HUD subview and returns it. 
  *
  * @param view The view that is going to be searched.
  * @return A reference to the last HUD subview discovered.
@@ -183,7 +183,7 @@ typedef void (^MBProgressHUDCompletionBlock)();
  */
 - (id)initWithView:(UIView *)view;
 
-/**
+/** 
  * Display the HUD. You need to make sure that the main thread completes its run loop soon after this method call so
  * the user interface can be updated. Call this method when your task is already set-up to be executed in a new thread
  * (e.g., when using something like NSOperation or calling an asynchronous call like NSURLRequest).
@@ -195,7 +195,7 @@ typedef void (^MBProgressHUDCompletionBlock)();
  */
 - (void)show:(BOOL)animated;
 
-/**
+/** 
  * Hide the HUD. This still calls the hudWasHidden: delegate. This is the counterpart of the show: method. Use it to
  * hide the HUD when your task completes.
  *
@@ -206,7 +206,7 @@ typedef void (^MBProgressHUDCompletionBlock)();
  */
 - (void)hide:(BOOL)animated;
 
-/**
+/** 
  * Hide the HUD after a delay. This still calls the hudWasHidden: delegate. This is the counterpart of the show: method. Use it to
  * hide the HUD when your task completes.
  *
@@ -218,7 +218,7 @@ typedef void (^MBProgressHUDCompletionBlock)();
  */
 - (void)hide:(BOOL)animated afterDelay:(NSTimeInterval)delay;
 
-/**
+/** 
  * Shows the HUD while a background task is executing in a new thread, then hides the HUD.
  *
  * This method also takes care of autorelease pools so your method does not have to be concerned with setting up a
@@ -255,7 +255,7 @@ typedef void (^MBProgressHUDCompletionBlock)();
  */
 - (void)showAnimated:(BOOL)animated whileExecutingBlock:(dispatch_block_t)block onQueue:(dispatch_queue_t)queue;
 
-/**
+/** 
  * Shows the HUD while a block is executing on the specified dispatch queue, executes completion block on the main queue, and then hides the HUD.
  *
  * @param animated If set to YES the HUD will (dis)appear using the current animationType. If set to NO the HUD will
@@ -276,7 +276,7 @@ typedef void (^MBProgressHUDCompletionBlock)();
 
 #endif
 
-/**
+/** 
  * MBProgressHUD operation mode. The default is MBProgressHUDModeIndeterminate.
  *
  * @see MBProgressHUDMode
@@ -284,7 +284,7 @@ typedef void (^MBProgressHUDCompletionBlock)();
 @property (assign) MBProgressHUDMode mode;
 
 /**
- * The animation type that should be used when the HUD is shown and hidden.
+ * The animation type that should be used when the HUD is shown and hidden. 
  *
  * @see MBProgressHUDAnimation
  */
@@ -292,32 +292,32 @@ typedef void (^MBProgressHUDCompletionBlock)();
 
 /**
  * The UIView (e.g., a UIImageView) to be shown when the HUD is in MBProgressHUDModeCustomView.
- * For best results use a 37 by 37 pixel view (so the bounds match the built in indicator bounds).
+ * For best results use a 37 by 37 pixel view (so the bounds match the built in indicator bounds). 
  */
 @property (MB_STRONG) UIView *customView;
 
-/**
- * The HUD delegate object.
+/** 
+ * The HUD delegate object. 
  *
  * @see MBProgressHUDDelegate
  */
 @property (MB_WEAK) id<MBProgressHUDDelegate> delegate;
 
-/**
+/** 
  * An optional short message to be displayed below the activity indicator. The HUD is automatically resized to fit
  * the entire text. If the text is too long it will get clipped by displaying "..." at the end. If left unchanged or
  * set to @"", then no message is displayed.
  */
 @property (copy) NSString *labelText;
 
-/**
+/** 
  * An optional details message displayed below the labelText message. This message is displayed only if the labelText
- * property is also set and is different from an empty string (@""). The details text can span multiple lines.
+ * property is also set and is different from an empty string (@""). The details text can span multiple lines. 
  */
 @property (copy) NSString *detailsLabelText;
 
-/**
- * The opacity of the HUD window. Defaults to 0.8 (80% opacity).
+/** 
+ * The opacity of the HUD window. Defaults to 0.8 (80% opacity). 
  */
 @property (assign) float opacity;
 
@@ -333,26 +333,26 @@ typedef void (^MBProgressHUDCompletionBlock)();
  */
 @property (assign) float xOffset;
 
-/**
- * The y-axis offset of the HUD relative to the centre of the superview.
+/** 
+ * The y-axis offset of the HUD relative to the centre of the superview. 
  */
 @property (assign) float yOffset;
 
 /**
- * The amount of space between the HUD edge and the HUD elements (labels, indicators or custom views).
+ * The amount of space between the HUD edge and the HUD elements (labels, indicators or custom views). 
  * Defaults to 20.0
  */
 @property (assign) float margin;
 
 /**
- * Cover the HUD background view with a radial gradient.
+ * Cover the HUD background view with a radial gradient. 
  */
 @property (assign) BOOL dimBackground;
 
 /*
- * Grace period is the time (in seconds) that the invoked method may be run without
+ * Grace period is the time (in seconds) that the invoked method may be run without 
  * showing the HUD. If the task finishes before the grace time runs out, the HUD will
- * not be shown at all.
+ * not be shown at all. 
  * This may be used to prevent HUD display for very short tasks.
  * Defaults to 0 (no grace time).
  * Grace time functionality is only supported when the task status is known!
@@ -361,7 +361,7 @@ typedef void (^MBProgressHUDCompletionBlock)();
 @property (assign) float graceTime;
 
 /**
- * The minimum time (in seconds) that the HUD is shown.
+ * The minimum time (in seconds) that the HUD is shown. 
  * This avoids the problem of the HUD being shown and than instantly hidden.
  * Defaults to 0 (no minimum show time).
  */
@@ -372,14 +372,14 @@ typedef void (^MBProgressHUDCompletionBlock)();
  * If you don't set a graceTime (different than 0.0) this does nothing.
  * This property is automatically set when using showWhileExecuting:onTarget:withObject:animated:.
  * When threading is done outside of the HUD (i.e., when the show: and hide: methods are used directly),
- * you need to set this property when your task starts and completes in order to have normal graceTime
+ * you need to set this property when your task starts and completes in order to have normal graceTime 
  * functionality.
  */
 @property (assign) BOOL taskInProgress;
 
 /**
- * Removes the HUD from its parent view when hidden.
- * Defaults to NO.
+ * Removes the HUD from its parent view when hidden. 
+ * Defaults to NO. 
  */
 @property (assign) BOOL removeFromSuperViewOnHide;
 
@@ -393,8 +393,8 @@ typedef void (^MBProgressHUDCompletionBlock)();
  */
 @property (MB_STRONG) UIFont* detailsLabelFont;
 
-/**
- * The progress of the progress indicator, from 0.0 to 1.0. Defaults to 0.0.
+/** 
+ * The progress of the progress indicator, from 0.0 to 1.0. Defaults to 0.0. 
  */
 @property (assign) float progress;
 
@@ -404,7 +404,7 @@ typedef void (^MBProgressHUDCompletionBlock)();
 @property (assign) CGSize minSize;
 
 /**
- * Force the HUD dimensions to be equal if possible.
+ * Force the HUD dimensions to be equal if possible. 
  */
 @property (assign, getter = isSquare) BOOL square;
 
@@ -420,8 +420,8 @@ typedef void (^MBProgressHUDCompletionBlock)();
 
 @optional
 
-/**
- * Called after the HUD was fully hidden from the screen.
+/** 
+ * Called after the HUD was fully hidden from the screen. 
  */
 - (void)hudWasHidden:(MBProgressHUD *)hud;
 
@@ -431,7 +431,7 @@ typedef void (^MBProgressHUDCompletionBlock)();
 /**
  * A progress view for showing definite progress by filling up a circle (pie chart).
  */
-@interface MBRoundProgressView : UIView
+@interface MBRoundProgressView : UIView 
 
 /**
  * Progress (0.0 to 1.0)

--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -8,34 +8,34 @@
 
 
 #if __has_feature(objc_arc)
-#define MB_AUTORELEASE(exp) exp
-#define MB_RELEASE(exp) exp
-#define MB_RETAIN(exp) exp
+	#define MB_AUTORELEASE(exp) exp
+	#define MB_RELEASE(exp) exp
+	#define MB_RETAIN(exp) exp
 #else
-#define MB_AUTORELEASE(exp) [exp autorelease]
-#define MB_RELEASE(exp) [exp release]
-#define MB_RETAIN(exp) [exp retain]
+	#define MB_AUTORELEASE(exp) [exp autorelease]
+	#define MB_RELEASE(exp) [exp release]
+	#define MB_RETAIN(exp) [exp retain]
 #endif
 
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= 60000
-#define MBLabelAlignmentCenter NSTextAlignmentCenter
+	#define MBLabelAlignmentCenter NSTextAlignmentCenter
 #else
-#define MBLabelAlignmentCenter UITextAlignmentCenter
+	#define MBLabelAlignmentCenter UITextAlignmentCenter
 #endif
 
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= 70000
-#define MB_TEXTSIZE(text, font) [text length] > 0 ? [text \
-sizeWithAttributes:@{NSFontAttributeName:font}] : CGSizeZero;
+	#define MB_TEXTSIZE(text, font) [text length] > 0 ? [text \
+		sizeWithAttributes:@{NSFontAttributeName:font}] : CGSizeZero;
 #else
 #define MB_TEXTSIZE(text, font) [text length] > 0 ? [text sizeWithFont:font] : CGSizeZero;
 #endif
 
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= 70000
-#define MB_MULTILINE_TEXTSIZE(text, font, maxSize, mode) [text length] > 0 ? [text \
-boundingRectWithSize:maxSize options:(NSStringDrawingUsesLineFragmentOrigin) \
-attributes:@{NSFontAttributeName:font} context:nil].size : CGSizeZero;
+	#define MB_MULTILINE_TEXTSIZE(text, font, maxSize, mode) [text length] > 0 ? [text \
+		boundingRectWithSize:maxSize options:(NSStringDrawingUsesLineFragmentOrigin) \
+		attributes:@{NSFontAttributeName:font} context:nil].size : CGSizeZero;
 #else
-#define MB_MULTILINE_TEXTSIZE(text, font, maxSize, mode) [text length] > 0 ? [text \
+	#define MB_MULTILINE_TEXTSIZE(text, font, maxSize, mode) [text length] > 0 ? [text \
 sizeWithFont:font constrainedToSize:maxSize lineBreakMode:mode] : CGSizeZero;
 #endif
 
@@ -342,7 +342,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 		} else if (animationType == MBProgressHUDAnimationZoomOut) {
 			self.transform = CGAffineTransformConcat(rotationTransform, CGAffineTransformMakeScale(0.5f, 0.5f));
 		}
-		
+
 		self.alpha = 0.02f;
 		[UIView commitAnimations];
 	}
@@ -413,7 +413,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
             [self cleanUp];
         });
     });
-	[self show:animated];
+  [self show:animated];
 }
 
 #endif
@@ -623,7 +623,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 	
 	CGContextRef context = UIGraphicsGetCurrentContext();
 	UIGraphicsPushContext(context);
-	
+
 	if (self.dimBackground) {
 		//Gradient colours
 		size_t gradLocationsNum = 2;
@@ -642,14 +642,14 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 									 kCGGradientDrawsAfterEndLocation);
 		CGGradientRelease(gradient);
 	}
-	
+
     // Set background rect color
     if (self.color) {
         CGContextSetFillColorWithColor(context, self.color.CGColor);
     } else {
         CGContextSetGrayFillColor(context, 0.0f, self.opacity);
     }
-	
+
 	
 	// Center HUD
 	CGRect allRect = self.bounds;
@@ -665,7 +665,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 	CGContextAddArc(context, CGRectGetMinX(boxRect) + radius, CGRectGetMinY(boxRect) + radius, radius, (float)M_PI, 3 * (float)M_PI / 2, 0);
 	CGContextClosePath(context);
 	CGContextFillPath(context);
-	
+
 	UIGraphicsPopContext();
 }
 
@@ -756,7 +756,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 		// Window coordinates differ!
 		self.bounds = CGRectMake(0, 0, self.bounds.size.height, self.bounds.size.width);
 	} else {
-		if (orientation == UIInterfaceOrientationPortraitUpsideDown) { radians = (CGFloat)M_PI; }
+		if (orientation == UIInterfaceOrientationPortraitUpsideDown) { radians = (CGFloat)M_PI; } 
 		else { radians = 0; }
 	}
 	rotationTransform = CGAffineTransformMakeRotation(radians);

--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -379,7 +379,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 - (void)showWhileExecuting:(SEL)method onTarget:(id)target withObject:(id)object animated:(BOOL)animated {
 	methodForExecution = method;
 	targetForExecution = MB_RETAIN(target);
-	objectForExecution = MB_RETAIN(object); 
+	objectForExecution = MB_RETAIN(object);	
 	// Launch execution in new thread
 	self.taskInProgress = YES;
 	[NSThread detachNewThreadSelector:@selector(launchExecution) toTarget:self withObject:nil];

--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -5,39 +5,38 @@
 //
 
 #import "MBProgressHUD.h"
-#import <tgmath.h>
 
 
 #if __has_feature(objc_arc)
-	#define MB_AUTORELEASE(exp) exp
-	#define MB_RELEASE(exp) exp
-	#define MB_RETAIN(exp) exp
+#define MB_AUTORELEASE(exp) exp
+#define MB_RELEASE(exp) exp
+#define MB_RETAIN(exp) exp
 #else
-	#define MB_AUTORELEASE(exp) [exp autorelease]
-	#define MB_RELEASE(exp) [exp release]
-	#define MB_RETAIN(exp) [exp retain]
+#define MB_AUTORELEASE(exp) [exp autorelease]
+#define MB_RELEASE(exp) [exp release]
+#define MB_RETAIN(exp) [exp retain]
 #endif
 
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= 60000
-    #define MBLabelAlignmentCenter NSTextAlignmentCenter
+#define MBLabelAlignmentCenter NSTextAlignmentCenter
 #else
-    #define MBLabelAlignmentCenter UITextAlignmentCenter
+#define MBLabelAlignmentCenter UITextAlignmentCenter
 #endif
 
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= 70000
-	#define MB_TEXTSIZE(text, font) [text length] > 0 ? [text \
-		sizeWithAttributes:@{NSFontAttributeName:font}] : CGSizeZero;
+#define MB_TEXTSIZE(text, font) [text length] > 0 ? [text \
+sizeWithAttributes:@{NSFontAttributeName:font}] : CGSizeZero;
 #else
-	#define MB_TEXTSIZE(text, font) [text length] > 0 ? [text sizeWithFont:font] : CGSizeZero;
+#define MB_TEXTSIZE(text, font) [text length] > 0 ? [text sizeWithFont:font] : CGSizeZero;
 #endif
 
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= 70000
-	#define MB_MULTILINE_TEXTSIZE(text, font, maxSize, mode) [text length] > 0 ? [text \
-		boundingRectWithSize:maxSize options:(NSStringDrawingUsesLineFragmentOrigin) \
-		attributes:@{NSFontAttributeName:font} context:nil].size : CGSizeZero;
+#define MB_MULTILINE_TEXTSIZE(text, font, maxSize, mode) [text length] > 0 ? [text \
+boundingRectWithSize:maxSize options:(NSStringDrawingUsesLineFragmentOrigin) \
+attributes:@{NSFontAttributeName:font} context:nil].size : CGSizeZero;
 #else
-	#define MB_MULTILINE_TEXTSIZE(text, font, maxSize, mode) [text length] > 0 ? [text \
-		sizeWithFont:font constrainedToSize:maxSize lineBreakMode:mode] : CGSizeZero;
+#define MB_MULTILINE_TEXTSIZE(text, font, maxSize, mode) [text length] > 0 ? [text \
+sizeWithFont:font constrainedToSize:maxSize lineBreakMode:mode] : CGSizeZero;
 #endif
 
 
@@ -94,9 +93,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 @synthesize opacity;
 @synthesize color;
 @synthesize labelFont;
-@synthesize labelColor;
 @synthesize detailsLabelFont;
-@synthesize detailsLabelColor;
 @synthesize indicator;
 @synthesize xOffset;
 @synthesize yOffset;
@@ -117,6 +114,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 @synthesize detailsLabelText;
 @synthesize progress;
 @synthesize size;
+@synthesize accessoryView;
 #if NS_BLOCKS_AVAILABLE
 @synthesize completionBlock;
 #endif
@@ -183,22 +181,19 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 		self.opacity = 0.8f;
         self.color = nil;
 		self.labelFont = [UIFont boldSystemFontOfSize:kLabelFontSize];
-        self.labelColor = [UIColor whiteColor];
 		self.detailsLabelFont = [UIFont boldSystemFontOfSize:kDetailsLabelFontSize];
-        self.detailsLabelColor = [UIColor whiteColor];
 		self.xOffset = 0.0f;
 		self.yOffset = 0.0f;
 		self.dimBackground = NO;
 		self.margin = 20.0f;
-        self.cornerRadius = 10.0f;
 		self.graceTime = 0.0f;
 		self.minShowTime = 0.0f;
 		self.removeFromSuperViewOnHide = NO;
 		self.minSize = CGSizeZero;
 		self.square = NO;
-		self.autoresizingMask = UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin 
-								| UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
-
+		self.autoresizingMask = UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin
+		| UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
+		
 		// Transparent background
 		self.opaque = NO;
 		self.backgroundColor = [UIColor clearColor];
@@ -252,10 +247,10 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 	useAnimation = animated;
 	// If the grace time is set postpone the HUD display
 	if (self.graceTime > 0.0) {
-		self.graceTimer = [NSTimer scheduledTimerWithTimeInterval:self.graceTime target:self 
-						   selector:@selector(handleGraceTimer:) userInfo:nil repeats:NO];
-	} 
-	// ... otherwise show the HUD imediately 
+		self.graceTimer = [NSTimer scheduledTimerWithTimeInterval:self.graceTime target:self
+														 selector:@selector(handleGraceTimer:) userInfo:nil repeats:NO];
+	}
+	// ... otherwise show the HUD imediately
 	else {
 		[self setNeedsDisplay];
 		[self showUsingAnimation:useAnimation];
@@ -269,10 +264,10 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 	if (self.minShowTime > 0.0 && showStarted) {
 		NSTimeInterval interv = [[NSDate date] timeIntervalSinceDate:showStarted];
 		if (interv < self.minShowTime) {
-			self.minShowTimer = [NSTimer scheduledTimerWithTimeInterval:(self.minShowTime - interv) target:self 
-								selector:@selector(handleMinShowTimer:) userInfo:nil repeats:NO];
+			self.minShowTimer = [NSTimer scheduledTimerWithTimeInterval:(self.minShowTime - interv) target:self
+															   selector:@selector(handleMinShowTimer:) userInfo:nil repeats:NO];
 			return;
-		} 
+		}
 	}
 	// ... otherwise hide the HUD immediately
 	[self hideUsingAnimation:useAnimation];
@@ -347,7 +342,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 		} else if (animationType == MBProgressHUDAnimationZoomOut) {
 			self.transform = CGAffineTransformConcat(rotationTransform, CGAffineTransformMakeScale(0.5f, 0.5f));
 		}
-
+		
 		self.alpha = 0.02f;
 		[UIView commitAnimations];
 	}
@@ -384,7 +379,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 - (void)showWhileExecuting:(SEL)method onTarget:(id)target withObject:(id)object animated:(BOOL)animated {
 	methodForExecution = method;
 	targetForExecution = MB_RETAIN(target);
-	objectForExecution = MB_RETAIN(object);	
+	objectForExecution = MB_RETAIN(object);
 	// Launch execution in new thread
 	self.taskInProgress = YES;
 	[NSThread detachNewThreadSelector:@selector(launchExecution) toTarget:self withObject:nil];
@@ -418,7 +413,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
             [self cleanUp];
         });
     });
-  [self show:animated];
+	[self show:animated];
 }
 
 #endif
@@ -456,7 +451,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 	label.textAlignment = MBLabelAlignmentCenter;
 	label.opaque = NO;
 	label.backgroundColor = [UIColor clearColor];
-	label.textColor = self.labelColor;
+	label.textColor = [UIColor whiteColor];
 	label.font = self.labelFont;
 	label.text = self.labelText;
 	[self addSubview:label];
@@ -467,7 +462,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 	detailsLabel.textAlignment = MBLabelAlignmentCenter;
 	detailsLabel.opaque = NO;
 	detailsLabel.backgroundColor = [UIColor clearColor];
-	detailsLabel.textColor = self.detailsLabelColor;
+	detailsLabel.textColor = [UIColor whiteColor];
 	detailsLabel.numberOfLines = 0;
 	detailsLabel.font = self.detailsLabelFont;
 	detailsLabel.text = self.detailsLabelText;
@@ -482,36 +477,46 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 	if (mode == MBProgressHUDModeIndeterminate &&  !isActivityIndicator) {
 		// Update to indeterminate indicator
 		[indicator removeFromSuperview];
+		[accessoryView removeFromSuperview];
 		self.indicator = MB_AUTORELEASE([[UIActivityIndicatorView alloc]
 										 initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhiteLarge]);
 		[(UIActivityIndicatorView *)indicator startAnimating];
 		[self addSubview:indicator];
+		[self addSubview:accessoryView];
 	}
 	else if (mode == MBProgressHUDModeDeterminateHorizontalBar) {
 		// Update to bar determinate indicator
 		[indicator removeFromSuperview];
+		[accessoryView removeFromSuperview];
         self.indicator = MB_AUTORELEASE([[MBBarProgressView alloc] init]);
 		[self addSubview:indicator];
+		[self addSubview:accessoryView];
 	}
 	else if (mode == MBProgressHUDModeDeterminate || mode == MBProgressHUDModeAnnularDeterminate) {
 		if (!isRoundIndicator) {
 			// Update to determinante indicator
 			[indicator removeFromSuperview];
+			[accessoryView removeFromSuperview];
 			self.indicator = MB_AUTORELEASE([[MBRoundProgressView alloc] init]);
 			[self addSubview:indicator];
+			[self addSubview:accessoryView];
 		}
 		if (mode == MBProgressHUDModeAnnularDeterminate) {
 			[(MBRoundProgressView *)indicator setAnnular:YES];
 		}
-	} 
+	}
 	else if (mode == MBProgressHUDModeCustomView && customView != indicator) {
 		// Update custom view indicator
 		[indicator removeFromSuperview];
+		[accessoryView removeFromSuperview];
 		self.indicator = customView;
 		[self addSubview:indicator];
+		[self addSubview:accessoryView];
 	} else if (mode == MBProgressHUDModeText) {
 		[indicator removeFromSuperview];
+		[accessoryView removeFromSuperview];
 		self.indicator = nil;
+		[self addSubview:accessoryView];
 	}
 }
 
@@ -542,8 +547,8 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 	if (labelSize.height > 0.f && indicatorF.size.height > 0.f) {
 		totalSize.height += kPadding;
 	}
-
-	CGFloat remainingHeight = bounds.size.height - totalSize.height - kPadding - 4 * margin; 
+	
+	CGFloat remainingHeight = bounds.size.height - totalSize.height - kPadding - 4 * margin;
 	CGSize maxSize = CGSizeMake(maxWidth, remainingHeight);
 	CGSize detailsLabelSize = MB_MULTILINE_TEXTSIZE(detailsLabel.text, detailsLabel.font, maxSize, detailsLabel.lineBreakMode);
 	totalSize.width = MAX(totalSize.width, detailsLabelSize.width);
@@ -556,10 +561,10 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 	totalSize.height += 2 * margin;
 	
 	// Position elements
-	CGFloat yPos = round(((bounds.size.height - totalSize.height) / 2)) + margin + yOffset;
+	CGFloat yPos = roundf(((bounds.size.height - totalSize.height) / 2)) + margin + yOffset;
 	CGFloat xPos = xOffset;
 	indicatorF.origin.y = yPos;
-	indicatorF.origin.x = round((bounds.size.width - indicatorF.size.width) / 2) + xPos;
+	indicatorF.origin.x = roundf((bounds.size.width - indicatorF.size.width) / 2) + xPos;
 	indicator.frame = indicatorF;
 	yPos += indicatorF.size.height;
 	
@@ -568,7 +573,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 	}
 	CGRect labelF;
 	labelF.origin.y = yPos;
-	labelF.origin.x = round((bounds.size.width - labelSize.width) / 2) + xPos;
+	labelF.origin.x = roundf((bounds.size.width - labelSize.width) / 2) + xPos;
 	labelF.size = labelSize;
 	label.frame = labelF;
 	yPos += labelF.size.height;
@@ -578,9 +583,19 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 	}
 	CGRect detailsLabelF;
 	detailsLabelF.origin.y = yPos;
-	detailsLabelF.origin.x = round((bounds.size.width - detailsLabelSize.width) / 2) + xPos;
+	detailsLabelF.origin.x = roundf((bounds.size.width - detailsLabelSize.width) / 2) + xPos;
 	detailsLabelF.size = detailsLabelSize;
 	detailsLabel.frame = detailsLabelF;
+	
+	UIView* bottomMostView = indicator;
+	if (detailsLabelText.length != 0) {
+		bottomMostView = detailsLabel;
+	}
+	else if (labelText.length != 0) {
+		bottomMostView = label;
+	}
+	accessoryView.center = bottomMostView.center;
+	accessoryView.frame = CGRectOffset(accessoryView.frame, 0, accessoryView.frame.size.height / 2 + bottomMostView.frame.size.height / 2);
 	
 	// Enforce minsize and quare rules
 	if (square) {
@@ -594,7 +609,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 	}
 	if (totalSize.width < minSize.width) {
 		totalSize.width = minSize.width;
-	} 
+	}
 	if (totalSize.height < minSize.height) {
 		totalSize.height = minSize.height;
 	}
@@ -608,12 +623,12 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 	
 	CGContextRef context = UIGraphicsGetCurrentContext();
 	UIGraphicsPushContext(context);
-
+	
 	if (self.dimBackground) {
 		//Gradient colours
 		size_t gradLocationsNum = 2;
 		CGFloat gradLocations[2] = {0.0f, 1.0f};
-		CGFloat gradColors[8] = {0.0f,0.0f,0.0f,0.0f,0.0f,0.0f,0.0f,0.75f}; 
+		CGFloat gradColors[8] = {0.0f,0.0f,0.0f,0.0f,0.0f,0.0f,0.0f,0.75f};
 		CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
 		CGGradientRef gradient = CGGradientCreateWithColorComponents(colorSpace, gradColors, gradLocations, gradLocationsNum);
 		CGColorSpaceRelease(colorSpace);
@@ -627,21 +642,21 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 									 kCGGradientDrawsAfterEndLocation);
 		CGGradientRelease(gradient);
 	}
-
+	
     // Set background rect color
     if (self.color) {
         CGContextSetFillColorWithColor(context, self.color.CGColor);
     } else {
         CGContextSetGrayFillColor(context, 0.0f, self.opacity);
     }
-
+	
 	
 	// Center HUD
 	CGRect allRect = self.bounds;
 	// Draw rounded HUD backgroud rect
-	CGRect boxRect = CGRectMake(round((allRect.size.width - size.width) / 2) + self.xOffset,
-								round((allRect.size.height - size.height) / 2) + self.yOffset, size.width, size.height);
-	float radius = self.cornerRadius;
+	CGRect boxRect = CGRectMake(roundf((allRect.size.width - size.width) / 2) + self.xOffset,
+								roundf((allRect.size.height - size.height) / 2) + self.yOffset, size.width, size.height);
+	float radius = 10.0f;
 	CGContextBeginPath(context);
 	CGContextMoveToPoint(context, CGRectGetMinX(boxRect) + radius, CGRectGetMinY(boxRect));
 	CGContextAddArc(context, CGRectGetMaxX(boxRect) - radius, CGRectGetMinY(boxRect) + radius, radius, 3 * (float)M_PI / 2, 0, 0);
@@ -650,7 +665,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 	CGContextAddArc(context, CGRectGetMinX(boxRect) + radius, CGRectGetMinY(boxRect) + radius, radius, (float)M_PI, 3 * (float)M_PI / 2, 0);
 	CGContextClosePath(context);
 	CGContextFillPath(context);
-
+	
 	UIGraphicsPopContext();
 }
 
@@ -669,8 +684,8 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 }
 
 - (NSArray *)observableKeypaths {
-	return [NSArray arrayWithObjects:@"mode", @"customView", @"labelText", @"labelFont", @"labelColor",
-			@"detailsLabelText", @"detailsLabelFont", @"detailsLabelColor", @"progress", nil];
+	return [NSArray arrayWithObjects:@"mode", @"customView", @"labelText", @"labelFont",
+			@"detailsLabelText", @"detailsLabelFont", @"progress", @"accessoryView", nil];
 }
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context {
@@ -682,20 +697,16 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 }
 
 - (void)updateUIForKeypath:(NSString *)keyPath {
-	if ([keyPath isEqualToString:@"mode"] || [keyPath isEqualToString:@"customView"]) {
+	if ([keyPath isEqualToString:@"mode"] || [keyPath isEqualToString:@"customView"] || [keyPath isEqualToString:@"accessoryView"]) {
 		[self updateIndicators];
 	} else if ([keyPath isEqualToString:@"labelText"]) {
 		label.text = self.labelText;
 	} else if ([keyPath isEqualToString:@"labelFont"]) {
 		label.font = self.labelFont;
-	} else if ([keyPath isEqualToString:@"labelColor"]) {
-		label.textColor = self.labelColor;
 	} else if ([keyPath isEqualToString:@"detailsLabelText"]) {
 		detailsLabel.text = self.detailsLabelText;
 	} else if ([keyPath isEqualToString:@"detailsLabelFont"]) {
 		detailsLabel.font = self.detailsLabelFont;
-	} else if ([keyPath isEqualToString:@"detailsLabelColor"]) {
-		detailsLabel.textColor = self.detailsLabelColor;
 	} else if ([keyPath isEqualToString:@"progress"]) {
 		if ([indicator respondsToSelector:@selector(setProgress:)]) {
 			[(id)indicator setProgress:progress];
@@ -710,7 +721,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 
 - (void)registerForNotifications {
 	NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
-	[nc addObserver:self selector:@selector(deviceOrientationDidChange:) 
+	[nc addObserver:self selector:@selector(deviceOrientationDidChange:)
 			   name:UIDeviceOrientationDidChangeNotification object:nil];
 }
 
@@ -718,19 +729,19 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 	[[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
-- (void)deviceOrientationDidChange:(NSNotification *)notification { 
+- (void)deviceOrientationDidChange:(NSNotification *)notification {
 	UIView *superview = self.superview;
 	if (!superview) {
 		return;
 	} else if ([superview isKindOfClass:[UIWindow class]]) {
 		[self setTransformForCurrentOrientation:YES];
 	} else {
-		self.frame = self.superview.bounds;
+		self.bounds = self.superview.bounds;
 		[self setNeedsDisplay];
 	}
 }
 
-- (void)setTransformForCurrentOrientation:(BOOL)animated {	
+- (void)setTransformForCurrentOrientation:(BOOL)animated {
 	// Stay in sync with the superview
 	if (self.superview) {
 		self.bounds = self.superview.bounds;
@@ -740,12 +751,12 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 	UIInterfaceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
 	CGFloat radians = 0;
 	if (UIInterfaceOrientationIsLandscape(orientation)) {
-		if (orientation == UIInterfaceOrientationLandscapeLeft) { radians = -(CGFloat)M_PI_2; } 
+		if (orientation == UIInterfaceOrientationLandscapeLeft) { radians = -(CGFloat)M_PI_2; }
 		else { radians = (CGFloat)M_PI_2; }
 		// Window coordinates differ!
 		self.bounds = CGRectMake(0, 0, self.bounds.size.height, self.bounds.size.width);
 	} else {
-		if (orientation == UIInterfaceOrientationPortraitUpsideDown) { radians = (CGFloat)M_PI; } 
+		if (orientation == UIInterfaceOrientationPortraitUpsideDown) { radians = (CGFloat)M_PI; }
 		else { radians = 0; }
 	}
 	rotationTransform = CGAffineTransformMakeRotation(radians);

--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -18,16 +18,16 @@
 #endif
 
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= 60000
-	#define MBLabelAlignmentCenter NSTextAlignmentCenter
+    #define MBLabelAlignmentCenter NSTextAlignmentCenter
 #else
-	#define MBLabelAlignmentCenter UITextAlignmentCenter
+    #define MBLabelAlignmentCenter UITextAlignmentCenter
 #endif
 
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= 70000
 	#define MB_TEXTSIZE(text, font) [text length] > 0 ? [text \
 		sizeWithAttributes:@{NSFontAttributeName:font}] : CGSizeZero;
 #else
-#define MB_TEXTSIZE(text, font) [text length] > 0 ? [text sizeWithFont:font] : CGSizeZero;
+	#define MB_TEXTSIZE(text, font) [text length] > 0 ? [text sizeWithFont:font] : CGSizeZero;
 #endif
 
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= 70000
@@ -36,7 +36,7 @@
 		attributes:@{NSFontAttributeName:font} context:nil].size : CGSizeZero;
 #else
 	#define MB_MULTILINE_TEXTSIZE(text, font, maxSize, mode) [text length] > 0 ? [text \
-sizeWithFont:font constrainedToSize:maxSize lineBreakMode:mode] : CGSizeZero;
+		sizeWithFont:font constrainedToSize:maxSize lineBreakMode:mode] : CGSizeZero;
 #endif
 
 
@@ -267,7 +267,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 			self.minShowTimer = [NSTimer scheduledTimerWithTimeInterval:(self.minShowTime - interv) target:self
 															   selector:@selector(handleMinShowTimer:) userInfo:nil repeats:NO];
 			return;
-		}
+		} 
 	}
 	// ... otherwise hide the HUD immediately
 	[self hideUsingAnimation:useAnimation];
@@ -379,7 +379,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 - (void)showWhileExecuting:(SEL)method onTarget:(id)target withObject:(id)object animated:(BOOL)animated {
 	methodForExecution = method;
 	targetForExecution = MB_RETAIN(target);
-	objectForExecution = MB_RETAIN(object);
+	objectForExecution = MB_RETAIN(object); 
 	// Launch execution in new thread
 	self.taskInProgress = YES;
 	[NSThread detachNewThreadSelector:@selector(launchExecution) toTarget:self withObject:nil];
@@ -504,7 +504,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 		if (mode == MBProgressHUDModeAnnularDeterminate) {
 			[(MBRoundProgressView *)indicator setAnnular:YES];
 		}
-	}
+	} 
 	else if (mode == MBProgressHUDModeCustomView && customView != indicator) {
 		// Update custom view indicator
 		[indicator removeFromSuperview];
@@ -547,8 +547,8 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 	if (labelSize.height > 0.f && indicatorF.size.height > 0.f) {
 		totalSize.height += kPadding;
 	}
-	
-	CGFloat remainingHeight = bounds.size.height - totalSize.height - kPadding - 4 * margin;
+
+	CGFloat remainingHeight = bounds.size.height - totalSize.height - kPadding - 4 * margin; 
 	CGSize maxSize = CGSizeMake(maxWidth, remainingHeight);
 	CGSize detailsLabelSize = MB_MULTILINE_TEXTSIZE(detailsLabel.text, detailsLabel.font, maxSize, detailsLabel.lineBreakMode);
 	totalSize.width = MAX(totalSize.width, detailsLabelSize.width);
@@ -609,7 +609,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 	}
 	if (totalSize.width < minSize.width) {
 		totalSize.width = minSize.width;
-	}
+	} 
 	if (totalSize.height < minSize.height) {
 		totalSize.height = minSize.height;
 	}
@@ -628,7 +628,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 		//Gradient colours
 		size_t gradLocationsNum = 2;
 		CGFloat gradLocations[2] = {0.0f, 1.0f};
-		CGFloat gradColors[8] = {0.0f,0.0f,0.0f,0.0f,0.0f,0.0f,0.0f,0.75f};
+		CGFloat gradColors[8] = {0.0f,0.0f,0.0f,0.0f,0.0f,0.0f,0.0f,0.75f}; 
 		CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
 		CGGradientRef gradient = CGGradientCreateWithColorComponents(colorSpace, gradColors, gradLocations, gradLocationsNum);
 		CGColorSpaceRelease(colorSpace);
@@ -721,7 +721,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 
 - (void)registerForNotifications {
 	NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
-	[nc addObserver:self selector:@selector(deviceOrientationDidChange:)
+	[nc addObserver:self selector:@selector(deviceOrientationDidChange:) 
 			   name:UIDeviceOrientationDidChangeNotification object:nil];
 }
 
@@ -729,7 +729,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 	[[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
-- (void)deviceOrientationDidChange:(NSNotification *)notification {
+- (void)deviceOrientationDidChange:(NSNotification *)notification { 
 	UIView *superview = self.superview;
 	if (!superview) {
 		return;
@@ -741,7 +741,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 	}
 }
 
-- (void)setTransformForCurrentOrientation:(BOOL)animated {
+- (void)setTransformForCurrentOrientation:(BOOL)animated {	
 	// Stay in sync with the superview
 	if (self.superview) {
 		self.bounds = self.superview.bounds;
@@ -751,7 +751,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 	UIInterfaceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
 	CGFloat radians = 0;
 	if (UIInterfaceOrientationIsLandscape(orientation)) {
-		if (orientation == UIInterfaceOrientationLandscapeLeft) { radians = -(CGFloat)M_PI_2; }
+		if (orientation == UIInterfaceOrientationLandscapeLeft) { radians = -(CGFloat)M_PI_2; } 
 		else { radians = (CGFloat)M_PI_2; }
 		// Window coordinates differ!
 		self.bounds = CGRectMake(0, 0, self.bounds.size.height, self.bounds.size.width);


### PR DESCRIPTION
Accessory views are always displayed centered beneath the bottom most element (i.e. the lowest label with text in it, or the indicator if there is no text).

The following is a screen shot of our use case:
![screen shot 2013-12-31 at 11 26 02 am](https://f.cloud.github.com/assets/3309832/1828000/1400ca4e-7249-11e3-8209-b184cb24452f.png)
