### PR TITLE
New variation in loader display: Inline variation

### DIFF
--- a/Demo/Classes/HudDemoViewController.m
+++ b/Demo/Classes/HudDemoViewController.m
@@ -249,6 +249,18 @@
 	[HUD showWhileExecuting:@selector(myTask) onTarget:self withObject:nil animated:YES];	
 }
 
+- (IBAction)showInline:(id)sender {
+    
+    MBProgressHUD *hud = [MBProgressHUD showHUDAddedTo:self.navigationController.view animated:YES];
+    
+    // Configure for text only and offset down
+    hud.mode = MBProgressHUDModeInline;
+    hud.labelText = @"Loading...";
+    hud.removeFromSuperViewOnHide = YES;
+    
+    [hud hide:YES afterDelay:3];
+}
+
 #pragma mark - Execution code
 
 - (void)myTask {

--- a/Demo/en.lproj/HudDemoViewController.xib
+++ b/Demo/en.lproj/HudDemoViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="5056" systemVersion="13E28" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="8191" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none">
     <dependencies>
-        <deployment version="528" defaultVersion="1072" identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3733"/>
+        <deployment version="528" identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="HudDemoViewController">
@@ -22,15 +22,16 @@
                 <outletCollection property="buttons" destination="79" id="mUt-YM-wkJ"/>
                 <outletCollection property="buttons" destination="111" id="2gl-eT-6Ke"/>
                 <outletCollection property="buttons" destination="115" id="L2G-gy-G5K"/>
+                <outletCollection property="buttons" destination="c7H-Id-WgL" id="84y-Vx-7od"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" id="52">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="697"/>
+            <rect key="frame" x="0.0" y="0.0" width="320" height="729"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="54">
-                    <rect key="frame" x="0.0" y="0.0" width="320" height="697"/>
+                    <rect key="frame" x="0.0" y="0.0" width="320" height="729"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                     <subviews>
                         <button opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="fill" buttonType="roundedRect" lineBreakMode="middleTruncation" id="9">
@@ -243,6 +244,22 @@
                                 <action selector="showWithColor:" destination="-1" eventType="touchUpInside" id="116"/>
                             </connections>
                         </button>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="c7H-Id-WgL">
+                            <rect key="frame" x="20" y="685" width="280" height="37"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                            <color key="backgroundColor" red="0.94901960780000005" green="0.95294117649999999" blue="0.96470588239999999" alpha="1" colorSpace="calibratedRGB"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                            <state key="normal" title="Inline">
+                                <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                            </state>
+                            <state key="highlighted">
+                                <color key="titleColor" red="0.0" green="0.2388461351" blue="0.49733664770000002" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                            </state>
+                            <connections>
+                                <action selector="showInline:" destination="-1" eventType="touchUpInside" id="Mdn-gJ-BCD"/>
+                            </connections>
+                        </button>
                         <button opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="fill" buttonType="roundedRect" lineBreakMode="middleTruncation" id="8">
                             <rect key="frame" x="20" y="20" width="280" height="40"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
@@ -263,6 +280,7 @@
                     <color key="backgroundColor" red="0.8862745098" green="0.90588235289999997" blue="0.92941176469999998" alpha="1" colorSpace="calibratedRGB"/>
                 </view>
             </subviews>
+            <nil key="simulatedStatusBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
         </scrollView>
     </objects>

--- a/MBProgressHUD.h
+++ b/MBProgressHUD.h
@@ -45,7 +45,9 @@ typedef NS_ENUM(NSInteger, MBProgressHUDMode) {
 	/** Shows a custom view */
 	MBProgressHUDModeCustomView,
 	/** Shows only labels */
-	MBProgressHUDModeText
+	MBProgressHUDModeText, 
+    /** Shows label inline with the activity indicator */
+    MBProgressHUDModeInline
 };
 
 typedef NS_ENUM(NSInteger, MBProgressHUDAnimation) {

--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -516,7 +516,13 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 	} else if (mode == MBProgressHUDModeText) {
 		[indicator removeFromSuperview];
 		self.indicator = nil;
-	}
+    } else if (mode == MBProgressHUDModeInline) {
+        [indicator removeFromSuperview];
+        self.indicator = MB_AUTORELEASE([[UIActivityIndicatorView alloc]
+                                         initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhite]);
+        [(UIActivityIndicatorView *)indicator startAnimating];
+        [self addSubview:indicator];
+    }
 }
 
 #pragma mark - Layout
@@ -540,70 +546,104 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 	totalSize.width = MAX(totalSize.width, indicatorF.size.width);
 	totalSize.height += indicatorF.size.height;
 	
-	CGSize labelSize = MB_TEXTSIZE(label.text, label.font);
-	labelSize.width = MIN(labelSize.width, maxWidth);
-	totalSize.width = MAX(totalSize.width, labelSize.width);
-	totalSize.height += labelSize.height;
-	if (labelSize.height > 0.f && indicatorF.size.height > 0.f) {
-		totalSize.height += kPadding;
-	}
-
-	CGFloat remainingHeight = bounds.size.height - totalSize.height - kPadding - 4 * margin; 
-	CGSize maxSize = CGSizeMake(maxWidth, remainingHeight);
-	CGSize detailsLabelSize = MB_MULTILINE_TEXTSIZE(detailsLabel.text, detailsLabel.font, maxSize, detailsLabel.lineBreakMode);
-	totalSize.width = MAX(totalSize.width, detailsLabelSize.width);
-	totalSize.height += detailsLabelSize.height;
-	if (detailsLabelSize.height > 0.f && (indicatorF.size.height > 0.f || labelSize.height > 0.f)) {
-		totalSize.height += kPadding;
-	}
-	
-	totalSize.width += 2 * margin;
-	totalSize.height += 2 * margin;
-	
-	// Position elements
-	CGFloat yPos = round(((bounds.size.height - totalSize.height) / 2)) + margin + yOffset;
-	CGFloat xPos = xOffset;
-	indicatorF.origin.y = yPos;
-	indicatorF.origin.x = round((bounds.size.width - indicatorF.size.width) / 2) + xPos;
-	indicator.frame = indicatorF;
-	yPos += indicatorF.size.height;
-	
-	if (labelSize.height > 0.f && indicatorF.size.height > 0.f) {
-		yPos += kPadding;
-	}
-	CGRect labelF;
-	labelF.origin.y = yPos;
-	labelF.origin.x = round((bounds.size.width - labelSize.width) / 2) + xPos;
-	labelF.size = labelSize;
-	label.frame = labelF;
-	yPos += labelF.size.height;
-	
-	if (detailsLabelSize.height > 0.f && (indicatorF.size.height > 0.f || labelSize.height > 0.f)) {
-		yPos += kPadding;
-	}
-	CGRect detailsLabelF;
-	detailsLabelF.origin.y = yPos;
-	detailsLabelF.origin.x = round((bounds.size.width - detailsLabelSize.width) / 2) + xPos;
-	detailsLabelF.size = detailsLabelSize;
-	detailsLabel.frame = detailsLabelF;
-	
-	// Enforce minsize and quare rules
-	if (square) {
-		CGFloat max = MAX(totalSize.width, totalSize.height);
-		if (max <= bounds.size.width - 2 * margin) {
-			totalSize.width = max;
-		}
-		if (max <= bounds.size.height - 2 * margin) {
-			totalSize.height = max;
-		}
-	}
-	if (totalSize.width < minSize.width) {
-		totalSize.width = minSize.width;
-	} 
-	if (totalSize.height < minSize.height) {
-		totalSize.height = minSize.height;
-	}
-	
+    CGSize labelSize = MB_TEXTSIZE(label.text, label.font);
+    labelSize.width = MIN(labelSize.width, maxWidth);
+    
+    if(mode != MBProgressHUDModeInline) {
+        totalSize.width = MAX(totalSize.width, labelSize.width);
+        
+        totalSize.height += labelSize.height;
+        if (labelSize.height > 0.f && indicatorF.size.height > 0.f) {
+            totalSize.height += kPadding;
+        }
+        
+        CGFloat remainingHeight = bounds.size.height - totalSize.height - kPadding - 4 * margin;
+        CGSize maxSize = CGSizeMake(maxWidth, remainingHeight);
+        CGSize detailsLabelSize = MB_MULTILINE_TEXTSIZE(detailsLabel.text, detailsLabel.font, maxSize, detailsLabel.lineBreakMode);
+        totalSize.width = MAX(totalSize.width, detailsLabelSize.width);
+        totalSize.height += detailsLabelSize.height;
+        if (detailsLabelSize.height > 0.f && (indicatorF.size.height > 0.f || labelSize.height > 0.f)) {
+            totalSize.height += kPadding;
+        }
+        
+        totalSize.width += 2 * margin;
+        totalSize.height += 2 * margin;
+        
+        // Position elements
+        CGFloat yPos = round(((bounds.size.height - totalSize.height) / 2)) + margin + yOffset;
+        CGFloat xPos = xOffset;
+        indicatorF.origin.y = yPos;
+        indicatorF.origin.x = round((bounds.size.width - indicatorF.size.width) / 2) + xPos;
+        indicator.frame = indicatorF;
+        yPos += indicatorF.size.height;
+        
+        if (labelSize.height > 0.f && indicatorF.size.height > 0.f) {
+            yPos += kPadding;
+        }
+        CGRect labelF;
+        labelF.origin.y = yPos;
+        labelF.origin.x = round((bounds.size.width - labelSize.width) / 2) + xPos;
+        labelF.size = labelSize;
+        label.frame = labelF;
+        yPos += labelF.size.height;
+        
+        if (detailsLabelSize.height > 0.f && (indicatorF.size.height > 0.f || labelSize.height > 0.f)) {
+            yPos += kPadding;
+        }
+        CGRect detailsLabelF;
+        detailsLabelF.origin.y = yPos;
+        detailsLabelF.origin.x = round((bounds.size.width - detailsLabelSize.width) / 2) + xPos;
+        detailsLabelF.size = detailsLabelSize;
+        detailsLabel.frame = detailsLabelF;
+        
+        // Enforce minsize and quare rules
+        if (square) {
+            CGFloat max = MAX(totalSize.width, totalSize.height);
+            if (max <= bounds.size.width - 2 * margin) {
+                totalSize.width = max;
+            }
+            if (max <= bounds.size.height - 2 * margin) {
+                totalSize.height = max;
+            }
+        }
+        if (totalSize.width < minSize.width) {
+            totalSize.width = minSize.width;
+        } 
+        if (totalSize.height < minSize.height) {
+            totalSize.height = minSize.height;
+        }
+    }
+    else {
+        // Inline mode
+        labelSize.width = MIN(labelSize.width, maxWidth);
+        
+        CGFloat indicatorPadding= 2 * kPadding;
+        CGFloat totalHorizontalMargin = (margin);
+        CGFloat totalVerticalMargin = (margin);
+        
+        totalSize.width = (labelSize.width + indicatorF.size.width + indicatorPadding);
+        totalSize.height = MAX(indicatorF.size.height, labelSize.height);
+        
+        totalSize.width += totalHorizontalMargin;
+        totalSize.height += totalVerticalMargin;
+        
+        // Position elements
+        CGFloat yPos = round(((bounds.size.height - totalSize.height) / 2)) + margin/2;
+        CGFloat xPos = round((totalHorizontalMargin)/2);
+        
+        indicatorF.origin.y = yPos;
+        indicatorF.origin.x = xPos + round(((bounds.size.width - totalSize.width)/2));
+        indicator.frame = indicatorF;
+        
+        CGRect labelF;
+        labelF.origin.y = yPos;
+        labelF.origin.x = CGRectGetMaxX(indicatorF) + indicatorPadding;
+        labelF.size = labelSize;
+        label.frame = labelF;
+        
+        detailsLabel.frame = CGRectZero;
+    }
+    
 	size = totalSize;
 }
 


### PR DESCRIPTION
New variation of display where the label is inline with the activity indicator. Details label is not available in this variation.

Cc: @matej 

![simulator screen shot 29-sep-2015 8 34 10 pm](https://cloud.githubusercontent.com/assets/2143499/10168397/2e802c1a-66ea-11e5-960c-c57e016dfae8.png)
